### PR TITLE
Make run script executable

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3.5
+
 """Run CactusBot."""
 
 from asyncio import get_event_loop


### PR DESCRIPTION
Adding a shebang line and adding the executable bit will make the
script executable, and controls exactly which Python version used.